### PR TITLE
Correctly Re-use PlotModel to Support Virtualization

### DIFF
--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
@@ -55,7 +55,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
                 return;
             }
 
-            this.CleanUpModel(base.Element.Model);
+            this.DetachModelFromView();
 
             var plotView = new PlotView(this.Context)
             {
@@ -83,7 +83,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
 
             if (e.PropertyName == Xamarin.Forms.PlotView.ModelProperty.PropertyName)
             {
-                this.CleanUpModel(base.Element.Model);
+                this.DetachModelFromView();
                 this.Control.Model = this.Element.Model;
             }
 
@@ -98,7 +98,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
             }
         }
  
-        void CleanUpModel(OxyPlot.PlotModel plot)
+        void DetachModelFromView())
         {
             var model = base.Element.Model as OxyPlot.IPlotModel;
             if (model != null)

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
@@ -98,7 +98,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
             }
         }
  
-        void DetachModelFromView())
+        void DetachModelFromView()
         {
             var model = base.Element.Model as OxyPlot.IPlotModel;
             if (model != null)

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/PlotViewRenderer.cs
@@ -55,6 +55,8 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
                 return;
             }
 
+            this.CleanUpModel(base.Element.Model);
+
             var plotView = new PlotView(this.Context)
             {
                 Model = this.Element.Model,
@@ -81,6 +83,7 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
 
             if (e.PropertyName == Xamarin.Forms.PlotView.ModelProperty.PropertyName)
             {
+                this.CleanUpModel(base.Element.Model);
                 this.Control.Model = this.Element.Model;
             }
 
@@ -92,6 +95,15 @@ namespace OxyPlot.Xamarin.Forms.Platform.Android
             if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
             {
                 this.Control.SetBackgroundColor(this.Element.BackgroundColor.ToAndroid());
+            }
+        }
+ 
+        void CleanUpModel(OxyPlot.PlotModel plot)
+        {
+            var model = base.Element.Model as OxyPlot.IPlotModel;
+            if (model != null)
+            {
+                model.AttachPlotView(null);
             }
         }
     }


### PR DESCRIPTION
Fixed OxyPlot.Xamarin.Forms bug that crashes app when plots are put in <see cref="TabbedPage"/> and are recycled.

this surely resolves issues in other virtualized view scenários.

the following exception was being thrown, there by crashing the app.

``` csharp
throw new InvalidOperationException("This PlotModel is already in use by some other PlotView control.")
```

This could also be fixed on the android side.

turning the following

``` csharp
// OxyPlot.Xamarin.Android.PlotView

public PlotModel Model
{
    get
    {
        return this.model;
    }
    set
    {
        if (this.model != value)
        {
            if (this.model != null)
            {
                ((IPlotModel)this.model).AttachPlotView(null);
                this.model = null;
            }
            if (value != null)
            {
                ((IPlotModel)value).AttachPlotView(this);
                this.model = value;
            }
            this.InvalidatePlot(true);
        }
    }
}
```

into

``` csharp
// OxyPlot.Xamarin.Android.PlotView

public PlotModel Model
{
    get
    {
        return this.model;
    }
    set
    {
        if (this.model != value)
        {
            this.DetachModelFromView(this.model);
            this.DetachModelFromView(value);
        }

        this.model = value;
        this.InvalidatePlot(true);
    }
}

void DetachModelFromView(OxyPlot.PlotModel model)
{
    var plotModel = model as OxyPlot.IPlotModel;
    if (plotModel != null)
    {
        plotModel.AttachPlotView(null);
    }
}
```
