### PR TITLE
Android density and scaled density are fixed.

### DIFF
--- a/Source/OxyPlot.Xamarin.Android/CanvasRenderContext.cs
+++ b/Source/OxyPlot.Xamarin.Android/CanvasRenderContext.cs
@@ -58,21 +58,27 @@ namespace OxyPlot.Xamarin.Android
         /// Initializes a new instance of the <see cref="CanvasRenderContext" /> class.
         /// </summary>
         /// <param name="scale">The scale.</param>
-        public CanvasRenderContext(double scale)
+        /// <param name="fontScale">The scale to use for text and font.</param>
+        public CanvasRenderContext(double scale, double fontScale)
         {
             this.paint = new Paint();
             this.path = new Path();
             this.bounds = new Rect();
             this.pts = new List<float>();
             this.Scale = scale;
+            this.FontScale = fontScale;
         }
 
         /// <summary>
-        /// Gets the factor that this.Scales from OxyPlot´s device independent pixels (96 dpi) to 
-        /// Android´s density-independent pixels (160 dpi).
+        /// Gets the factor for Android´s density-independent pixels (160 dpi as baseline density).
         /// </summary>
         /// <remarks>See <a href="http://developer.android.com/guide/practices/screens_support.html">Supporting multiple screens.</a>.</remarks>
         public double Scale { get; private set; }
+
+        /// <summary>
+        /// Gets the factor for Android's scale-independent pixels (160 dpi as baseline density).
+        /// </summary>
+        public double FontScale { get; private set; }
 
         /// <summary>
         /// Sets the target.
@@ -351,7 +357,7 @@ namespace OxyPlot.Xamarin.Android
                 float lineHeight, delta;
                 this.GetFontMetrics(this.paint, out lineHeight, out delta);
                 this.paint.GetTextBounds(text, 0, text.Length, this.bounds);
-                return new OxySize(this.bounds.Width() / this.Scale, lineHeight / this.Scale);
+                return new OxySize(this.bounds.Width() / this.FontScale, lineHeight / this.FontScale);
             }
         }
 

--- a/Source/OxyPlot.Xamarin.Android/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Android/PlotView.cs
@@ -25,10 +25,10 @@ namespace OxyPlot.Xamarin.Android
     {
         /// <summary>
         /// The factor that scales from OxyPlot´s device independent pixels (96 dpi) to 
-        /// Android´s density-independent pixels (160 dpi).
+        /// Android´s current density-independent pixels (dpi).
         /// </summary>
         /// <remarks>See <a href="http://developer.android.com/guide/practices/screens_support.html">Supporting multiple screens.</a>.</remarks>
-        public const double Scale = 160d / 96d;
+        public double Scale;
 
         /// <summary>
         /// The rendering lock object.
@@ -344,7 +344,13 @@ namespace OxyPlot.Xamarin.Android
             {
                 if (this.rc == null)
                 {
-                    this.rc = new CanvasRenderContext(Scale);
+                    var displayMetrics = this.Context.Resources.DisplayMetrics;
+
+                    // The factors for scaling to Android's DPI and SPI units.
+                    // The density independent pixel is equivalent to one physical pixel 
+                    // on a 160 dpi screen (baseline density)
+                    this.Scale = displayMetrics.Density;
+                    this.rc = new CanvasRenderContext(Scale, displayMetrics.ScaledDensity);
                 }
 
                 this.rc.SetTarget(canvas);


### PR DESCRIPTION
It fixes #28.

Current DPI is taken from display metrics for current view. Font scale is defined separately.
