### PR TITLE
#81 - (Mac) Fix PlotView mouse event position being relative to the window instead of the PlotView

### DIFF
--- a/Source/OxyPlot.Xamarin.Mac/ConverterExtensions.cs
+++ b/Source/OxyPlot.Xamarin.Mac/ConverterExtensions.cs
@@ -32,17 +32,6 @@ namespace OxyPlot.Xamarin.Mac
         }
 
         /// <summary>
-        /// Converts a <see cref="System.Drawing.PointF" /> to a <see cref="ScreenPoint" />.
-        /// </summary>
-        /// <param name="p">The point to convert.</param>
-		/// <param name="bounds">The bounds of the window.</param> 
-        /// <returns>The converted point.</returns>
-        public static ScreenPoint LocationToScreenPoint (this CGPoint p, CGRect bounds)
-        {
-            return new ScreenPoint (p.X, bounds.Height - p.Y);
-        }
-
-        /// <summary>
         /// Converts a <see cref="OxyColor" /> to a <see cref="CGColor" />.
         /// </summary>
         /// <param name="c">The color to convert.</param>
@@ -155,65 +144,6 @@ namespace OxyPlot.Xamarin.Mac
                 keys |= OxyModifierKeys.Control;
 
             return keys;
-        }
-
-		/// <summary>
-		/// Converts a <see cref="NSEvent" /> to a <see cref="OxyMouseDownEventArgs" />.
-		/// </summary>
-		/// <param name="theEvent">The event to convert.</param>
-		/// <param name="bounds">The bounds of the window.</param> 
-		/// <returns>The converted event arguments.</returns>
-        public static OxyMouseDownEventArgs ToMouseDownEventArgs (this NSEvent theEvent, CGRect bounds)
-        {
-            // https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSEvent_Class/Reference/Reference.html
-            return new OxyMouseDownEventArgs {
-                Position = theEvent.LocationInWindow.LocationToScreenPoint (bounds),
-                ChangedButton = theEvent.Type.ToButton (),
-                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
-                ClickCount = (int)theEvent.ClickCount,
-            };
-        }
-
-		/// <summary>
-		/// Converts a <see cref="NSEvent" /> to a <see cref="OxyMouseEventArgs" />.
-		/// </summary>
-		/// <param name="theEvent">The event to convert.</param>
-		/// <param name="bounds">The bounds of the window.</param> 
-		/// <returns>The converted event arguments.</returns>
-        public static OxyMouseEventArgs ToMouseEventArgs (this NSEvent theEvent, CGRect bounds)
-        {
-            return new OxyMouseEventArgs {
-                Position = theEvent.LocationInWindow.LocationToScreenPoint (bounds),
-                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
-            };
-        }
-
-		/// <summary>
-		/// Converts a <see cref="NSEvent" /> to a <see cref="OxyMouseWheelEventArgs" />.
-		/// </summary>
-		/// <param name="theEvent">The event to convert.</param>
-		/// <param name="bounds">The bounds of the window.</param> 
-		/// <returns>The converted event arguments.</returns>
-        public static OxyMouseWheelEventArgs ToMouseWheelEventArgs (this NSEvent theEvent, CGRect bounds)
-        {
-            return new OxyMouseWheelEventArgs {
-                Delta = (int)theEvent.ScrollingDeltaY,
-                Position = theEvent.LocationInWindow.LocationToScreenPoint (bounds),
-                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
-            };
-        }
-
-		/// <summary>
-		/// Converts a <see cref="NSEvent" /> to a <see cref="OxyKeyEventArgs" />.
-		/// </summary>
-		/// <param name="theEvent">The event to convert.</param>
-		/// <returns>The converted event arguments.</returns>
-        public static OxyKeyEventArgs ToKeyEventArgs (this NSEvent theEvent)
-        {
-            return new OxyKeyEventArgs {
-                Key = theEvent.KeyCode.ToKey (),
-                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
-            };
         }
 
 		/// <summary>

--- a/Source/OxyPlot.Xamarin.Mac/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Mac/PlotView.cs
@@ -314,7 +314,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseDown (NSEvent theEvent)
         {
             base.MouseDown (theEvent);
-            this.ActualController.HandleMouseDown (this, theEvent.ToMouseDownEventArgs(this.Bounds));
+            this.ActualController.HandleMouseDown (this, this.ToMouseDownEventArgs (theEvent));
         }
 
 		/// <summary>
@@ -324,7 +324,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseDragged (NSEvent theEvent)
         {
             base.MouseDragged (theEvent);
-            this.ActualController.HandleMouseMove (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseMove (this, this.ToMouseEventArgs (theEvent));
         }
 
 		/// <summary>
@@ -334,7 +334,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseMoved (NSEvent theEvent)
         {
             base.MouseMoved (theEvent);
-            this.ActualController.HandleMouseMove (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseMove (this, this.ToMouseEventArgs (theEvent));
         }
 
 		/// <summary>
@@ -344,7 +344,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseUp (NSEvent theEvent)
         {
             base.MouseUp (theEvent);
-            this.ActualController.HandleMouseUp (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseUp (this, this.ToMouseEventArgs (theEvent));
         }
 
 		/// <summary>
@@ -354,7 +354,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseEntered (NSEvent theEvent)
         {
             base.MouseEntered (theEvent);
-            this.ActualController.HandleMouseEnter (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseEnter (this, this.ToMouseEventArgs (theEvent));
         }
 
 		/// <summary>
@@ -364,7 +364,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void MouseExited (NSEvent theEvent)
         {
             base.MouseExited (theEvent);
-            this.ActualController.HandleMouseLeave (this, theEvent.ToMouseEventArgs (this.Bounds));
+            this.ActualController.HandleMouseLeave (this, this.ToMouseEventArgs (theEvent));
         }
 
 		/// <summary>
@@ -375,7 +375,7 @@ namespace OxyPlot.Xamarin.Mac
         {
             // TODO: use scroll events to pan?
             base.ScrollWheel (theEvent);
-            this.ActualController.HandleMouseWheel (this, theEvent.ToMouseWheelEventArgs (this.Bounds));
+            this.ActualController.HandleMouseWheel (this, this.ToMouseWheelEventArgs (theEvent));
         }
 
 		/// <summary>
@@ -403,7 +403,7 @@ namespace OxyPlot.Xamarin.Mac
         public override void KeyDown (NSEvent theEvent)
         {
             base.KeyDown (theEvent);
-            this.ActualController.HandleKeyDown (this, theEvent.ToKeyEventArgs ());
+            this.ActualController.HandleKeyDown (this, this.ToKeyEventArgs(theEvent));
         }
 
 		/// <summary>
@@ -442,6 +442,51 @@ namespace OxyPlot.Xamarin.Mac
         public override void SwipeWithEvent (NSEvent theEvent)
         {
             base.SwipeWithEvent (theEvent);
+        }
+
+        private OxyMouseDownEventArgs ToMouseDownEventArgs (NSEvent theEvent)
+        {
+            // https://developer.apple.com/library/mac/documentation/Cocoa/Reference/ApplicationKit/Classes/NSEvent_Class/Reference/Reference.html
+            return new OxyMouseDownEventArgs {
+                Position = this.GetRelativePosition(theEvent),
+                ChangedButton = theEvent.Type.ToButton (),
+                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
+                ClickCount = (int)theEvent.ClickCount,
+            };
+        }
+
+        private OxyMouseEventArgs ToMouseEventArgs (NSEvent theEvent)
+        {
+            return new OxyMouseEventArgs {
+                Position = this.GetRelativePosition(theEvent),
+                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
+            };
+        }
+
+        private OxyMouseWheelEventArgs ToMouseWheelEventArgs (NSEvent theEvent)
+        {
+            return new OxyMouseWheelEventArgs {
+                Delta = (int)theEvent.ScrollingDeltaY,
+                Position = this.GetRelativePosition(theEvent),
+                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
+            };
+        }
+
+        private OxyKeyEventArgs ToKeyEventArgs (NSEvent theEvent)
+        {
+            return new OxyKeyEventArgs {
+                Key = theEvent.KeyCode.ToKey (),
+                ModifierKeys = theEvent.ModifierFlags.ToModifierKeys (),
+            };
+        }
+
+        /// <summary>
+        /// Gets the event's position relative to this view.
+        /// </summary>
+        private ScreenPoint GetRelativePosition (NSEvent p)
+        {
+            var relativePoint = this.ConvertPointFromView (p.LocationInWindow, null);
+            return new ScreenPoint (relativePoint.X, relativePoint.Y);
         }
     }
 }


### PR DESCRIPTION
Fixes #81

This is a breaking change to `OxyMouseEventArgs.Position` on Mac.

I do not have any automated tests for this.

One way to test this manually (I have not done this):
- create a plot in the bottom-right quadrant of a window
- log the mouse position using `IController.HandleMouseMove`
- move the mouse over the top-left corner of the plot and record the position
- do these steps on WPF and Mac and compare results
  - before this PR, the results should differ
  - after this PR, the results should be the same