### PR TITLE
Remove unused package references

### DIFF
--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/MainPage.xaml.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/MainPage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 

--- a/Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.csproj
+++ b/Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.csproj
@@ -53,7 +53,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="OxyPlot">
       <HintPath>..\packages\OxyPlot.Core.2.0.0\lib\netstandard1.0\OxyPlot.dll</HintPath>
     </Reference>

--- a/Source/OxyPlot.Xamarin.Android/packages.config
+++ b/Source/OxyPlot.Xamarin.Android/packages.config
@@ -20,9 +20,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Linq" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Net.Http" version="4.3.4" targetFramework="monoandroid81" />
-  <package id="System.Net.Primitives" version="4.3.1" targetFramework="monoandroid81" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Reflection" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="monoandroid81" />

--- a/Source/OxyPlot.Xamarin.Android/packages.config
+++ b/Source/OxyPlot.Xamarin.Android/packages.config
@@ -35,9 +35,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="monoandroid81" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="monoandroid81" />
   <package id="System.Threading" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid81" />

--- a/Source/OxyPlot.Xamarin.Android/packages.config
+++ b/Source/OxyPlot.Xamarin.Android/packages.config
@@ -31,10 +31,6 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="monoandroid81" />
   <package id="System.Threading" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid81" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/OxyPlot.Xamarin.Forms.Platform.Android.csproj
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/OxyPlot.Xamarin.Forms.Platform.Android.csproj
@@ -57,7 +57,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/packages.config
@@ -32,10 +32,6 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="monoandroid81" />
   <package id="System.Threading" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid81" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/packages.config
@@ -21,9 +21,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Linq" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Net.Http" version="4.3.3" targetFramework="monoandroid81" />
-  <package id="System.Net.Primitives" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Reflection" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="monoandroid81" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/packages.config
@@ -36,9 +36,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="monoandroid81" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="monoandroid81" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="monoandroid81" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="monoandroid81" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/packages.config
@@ -32,10 +32,6 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinmac20" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/packages.config
@@ -36,9 +36,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinmac20" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/packages.config
@@ -21,9 +21,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Linq" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Net.Http" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Net.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Reflection" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="xamarinmac20" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/OxyPlot.Xamarin.Forms.Platform.iOS.csproj
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/OxyPlot.Xamarin.Forms.Platform.iOS.csproj
@@ -56,7 +56,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/packages.config
@@ -21,9 +21,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Linq" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Net.Http" version="4.3.3" targetFramework="xamarinios10" />
-  <package id="System.Net.Primitives" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Reflection" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="xamarinios10" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/packages.config
@@ -32,10 +32,6 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="xamarinios10" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinios10" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/packages.config
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/packages.config
@@ -36,9 +36,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="xamarinios10" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinios10" />

--- a/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.csproj
+++ b/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.csproj
@@ -61,15 +61,13 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="OxyPlot">
       <HintPath>..\packages\OxyPlot.Core.2.0.0\lib\netstandard1.0\OxyPlot.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
-		<Reference Include="Xamarin.Mac"/>
+		<Reference Include="Xamarin.Mac" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
 		<Reference Include="Xamarin.Mac">

--- a/Source/OxyPlot.Xamarin.Mac/packages.config
+++ b/Source/OxyPlot.Xamarin.Mac/packages.config
@@ -36,9 +36,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="xamarinmac20" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="xamarinmac20" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinmac20" />

--- a/Source/OxyPlot.Xamarin.Mac/packages.config
+++ b/Source/OxyPlot.Xamarin.Mac/packages.config
@@ -32,10 +32,6 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="xamarinmac20" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinmac20" />

--- a/Source/OxyPlot.Xamarin.Mac/packages.config
+++ b/Source/OxyPlot.Xamarin.Mac/packages.config
@@ -21,9 +21,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Linq" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="xamarinmac20" />
-  <package id="System.Net.Http" version="4.3.4" targetFramework="xamarinmac20" />
-  <package id="System.Net.Primitives" version="4.3.1" targetFramework="xamarinmac20" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Reflection" version="4.3.0" targetFramework="xamarinmac20" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="xamarinmac20" />

--- a/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.csproj
+++ b/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.csproj
@@ -58,7 +58,6 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="OxyPlot">
       <HintPath>..\packages\OxyPlot.Core.2.0.0\lib\netstandard1.0\OxyPlot.dll</HintPath>
     </Reference>
@@ -73,6 +72,9 @@
     <Compile Include="ExportExtensions.cs" />
     <Compile Include="PanZoomGestureRecognizer.cs" />
     <Compile Include="PlotView.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <Import Project="..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets" Condition="Exists('..\packages\NETStandard.Library.2.0.3\build\netstandard2.0\NETStandard.Library.targets')" />

--- a/Source/OxyPlot.Xamarin.iOS/packages.config
+++ b/Source/OxyPlot.Xamarin.iOS/packages.config
@@ -21,9 +21,6 @@
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Linq" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Net.Http" version="4.3.4" targetFramework="xamarinios10" />
-  <package id="System.Net.Primitives" version="4.3.1" targetFramework="xamarinios10" />
-  <package id="System.Net.Sockets" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Reflection" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="xamarinios10" />

--- a/Source/OxyPlot.Xamarin.iOS/packages.config
+++ b/Source/OxyPlot.Xamarin.iOS/packages.config
@@ -32,10 +32,6 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="xamarinios10" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinios10" />

--- a/Source/OxyPlot.Xamarin.iOS/packages.config
+++ b/Source/OxyPlot.Xamarin.iOS/packages.config
@@ -36,9 +36,6 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="xamarinios10" />
-  <package id="System.Text.Encoding" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="xamarinios10" />
-  <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="xamarinios10" />
   <package id="System.Threading" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="xamarinios10" />


### PR DESCRIPTION
... to `System.Net.*`, `System.Text.*` and `System.Security.*`.

I think there are several more unused packages, but I'm currently too lazy to look through all of them ;)
This should be enough to get rid of all the (unnecessary) dependabot updates (#116 etc).