### PR TITLE
Update OxyPlot.Core to 2.1.0

### DIFF
--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/App.xaml.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/App.xaml.cs
@@ -32,15 +32,15 @@ namespace SimpleDemo
                         },
                         Series =
                         {
-                            new ColumnSeries
+                            new BarSeries
                             {
                                 Items =
                                 {
-                                    new ColumnItem {Value = 3},
-                                    new ColumnItem {Value = 14},
-                                    new ColumnItem {Value = 11},
-                                    new ColumnItem {Value = 12},
-                                    new ColumnItem {Value = 7}
+                                    new BarItem {Value = 3},
+                                    new BarItem {Value = 14},
+                                    new BarItem {Value = 11},
+                                    new BarItem {Value = 12},
+                                    new BarItem {Value = 7}
                                 }
                             }
                         }

--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/App.xaml.cs
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/App.xaml.cs
@@ -24,16 +24,18 @@ namespace SimpleDemo
                 {
                     Model = new PlotModel
                     {
-                        Title = "OxyPlot in Xamarin Forms.",
+                        Title = "OxyPlot in Xamarin.Forms",
                         Axes =
                         {
-                            new CategoryAxis {Position = AxisPosition.Bottom},
-                            new LinearAxis {Position = AxisPosition.Left, MinimumPadding = 0}
+                            new CategoryAxis {Position = AxisPosition.Bottom, Key = "Y" },
+                            new LinearAxis {Position = AxisPosition.Left, Key = "X", MinimumPadding = 0}
                         },
                         Series =
                         {
                             new BarSeries
                             {
+                                XAxisKey = "X",
+                                YAxisKey = "Y",
                                 Items =
                                 {
                                     new BarItem {Value = 3},

--- a/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/SimpleDemo.csproj
+++ b/Source/Examples/Xamarin.Forms/SimpleDemo/SimpleDemo/SimpleDemo.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2545" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.4" />
   </ItemGroup>

--- a/Source/OxyPlot.Windows/OxyPlot.Windows.csproj
+++ b/Source/OxyPlot.Windows/OxyPlot.Windows.csproj
@@ -16,6 +16,6 @@
         <None Include="..\..\OxyPlot_128.png" Pack="true" PackagePath="\" />
     </ItemGroup>
     <ItemGroup>
-      <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
+      <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
     </ItemGroup>
 </Project>

--- a/Source/OxyPlot.Windows/PlotView.cs
+++ b/Source/OxyPlot.Windows/PlotView.cs
@@ -914,7 +914,8 @@ namespace OxyPlot.Windows
 
             if (this.ActualModel != null)
             {
-                ((IPlotModel)this.ActualModel).Render(this.renderContext, this.canvas.ActualWidth, this.canvas.ActualHeight);
+                OxyRect rect = new OxyRect(0, 0, canvas.ActualWidth, canvas.ActualHeight);
+                ((IPlotModel)this.ActualModel).Render(this.renderContext, rect);
             }
         }
 

--- a/Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.csproj
+++ b/Source/OxyPlot.Xamarin.Android/OxyPlot.Xamarin.Android.csproj
@@ -73,7 +73,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="OxyPlot.Core">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="System.Collections">
       <Version>4.3.0</Version>

--- a/Source/OxyPlot.Xamarin.Android/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Android/PlotView.cs
@@ -354,8 +354,9 @@ namespace OxyPlot.Xamarin.Android
                 }
 
                 this.rc.SetTarget(canvas);
-                
-                ((IPlotModel)actualModel).Render(this.rc, Width / Scale, Height / Scale);
+
+                OxyRect rect = new OxyRect(0, 0, Width / Scale, Height / Scale);
+                ((IPlotModel)actualModel).Render(this.rc, rect);
             }
         }
 

--- a/Source/OxyPlot.Xamarin.Forms.Platform.Android/OxyPlot.Xamarin.Forms.Platform.Android.csproj
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.Android/OxyPlot.Xamarin.Forms.Platform.Android.csproj
@@ -59,7 +59,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.4" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2545" />
     <PackageReference Include="NuGet.Build.Packaging">

--- a/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/OxyPlot.Xamarin.Forms.Platform.MacOS.csproj
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/OxyPlot.Xamarin.Forms.Platform.MacOS.csproj
@@ -64,6 +64,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
     <Reference Include="Xamarin.Mac" />

--- a/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/OxyPlot.Xamarin.Forms.Platform.MacOS.csproj
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.MacOS/OxyPlot.Xamarin.Forms.Platform.MacOS.csproj
@@ -74,15 +74,13 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.4" />
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2545" />
     <PackageReference Include="NuGet.Build.Packaging">
       <Version>0.2.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Xamarin.Forms">
-      <Version>5.0.0.2545</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Source/OxyPlot.Xamarin.Forms.Platform.UWP/OxyPlot.Xamarin.Forms.Platform.UWP.csproj
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.UWP/OxyPlot.Xamarin.Forms.Platform.UWP.csproj
@@ -123,7 +123,7 @@
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="OxyPlot.Core">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2545</Version>

--- a/Source/OxyPlot.Xamarin.Forms.Platform.iOS/OxyPlot.Xamarin.Forms.Platform.iOS.csproj
+++ b/Source/OxyPlot.Xamarin.Forms.Platform.iOS/OxyPlot.Xamarin.Forms.Platform.iOS.csproj
@@ -63,7 +63,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
     <PackageReference Include="NuGet.Build.Packaging">
       <Version>0.2.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/OxyPlot.Xamarin.Forms.nuspec
+++ b/Source/OxyPlot.Xamarin.Forms.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>OxyPlot.Xamarin.Forms</id>
     <title>OxyPlot for Xamarin (Android, iOS, Mac and UWP)</title>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <authors>Oystein Bjorke, Janus Weil</authors>
     <description>OxyPlot is a plotting library for .NET. This package includes a portable library for Xamarin.Forms apps and platform-specific libraries for Android, iOS, Mac and UWP.</description>
     <releaseNotes></releaseNotes>
@@ -16,27 +16,27 @@
     <tags>plotting plot charting chart xamarin forms android ios mac uwp</tags>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="OxyPlot.Core" version="2.0.0"/>
+        <dependency id="OxyPlot.Core" version="2.1.0"/>
         <dependency id="Xamarin.Forms" version="5.0" />
         <dependency id="Xamarin.Essentials" version="1.3" />
       </group>
       <group targetFramework="MonoAndroid10">
-        <dependency id="OxyPlot.Core" version="2.0.0"/>
+        <dependency id="OxyPlot.Core" version="2.1.0"/>
         <dependency id="Xamarin.Forms" version="5.0" />
         <dependency id="Xamarin.Essentials" version="1.3" />
       </group>
       <group targetFramework="uap10.0">
-        <dependency id="OxyPlot.Core" version="2.0.0"/>
+        <dependency id="OxyPlot.Core" version="2.1.0"/>
         <dependency id="Xamarin.Forms" version="5.0" />
         <dependency id="Xamarin.Essentials" version="1.3" />
       </group>
       <group targetFramework="Xamarin.Mac20">
-        <dependency id="OxyPlot.Core" version="2.0.0"/>
+        <dependency id="OxyPlot.Core" version="2.1.0"/>
         <dependency id="Xamarin.Forms" version="5.0" />
         <dependency id="Xamarin.Essentials" version="1.3" />
       </group>
       <group targetFramework="netstandard2.0">
-        <dependency id="OxyPlot.Core" version="2.0.0"/>
+        <dependency id="OxyPlot.Core" version="2.1.0"/>
         <dependency id="Xamarin.Forms" version="5.0" />
         <dependency id="Xamarin.Essentials" version="1.3" />
       </group>

--- a/Source/OxyPlot.Xamarin.Forms/OxyPlot.Xamarin.Forms.csproj
+++ b/Source/OxyPlot.Xamarin.Forms/OxyPlot.Xamarin.Forms.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
+    <PackageReference Include="OxyPlot.Core" Version="2.1.0" />
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2545" />
     <PackageReference Include="Xamarin.Essentials" Version="1.7.4" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">

--- a/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.csproj
+++ b/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' != 'Windows_NT'">
     <Reference Include="Xamarin.Mac" />

--- a/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.csproj
+++ b/Source/OxyPlot.Xamarin.Mac/OxyPlot.Xamarin.Mac.csproj
@@ -88,7 +88,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="OxyPlot.Core">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="System.Collections">
       <Version>4.3.0</Version>

--- a/Source/OxyPlot.Xamarin.Mac/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.Mac/PlotView.cs
@@ -300,8 +300,9 @@ namespace OxyPlot.Xamarin.Mac
                 // TODO: scale font matrix??
                 using (var renderer = new CoreGraphicsRenderContext(context))
                 {
-                        ((IPlotModel)this.model).Render(renderer, dirtyRect.Width, dirtyRect.Height);
-                    }
+                    OxyRect orect = new OxyRect(0, 0, dirtyRect.Width, dirtyRect.Height);
+                    ((IPlotModel)this.model).Render(renderer, orect);
+                }
             }
         }
 

--- a/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.csproj
+++ b/Source/OxyPlot.Xamarin.iOS/OxyPlot.Xamarin.iOS.csproj
@@ -82,7 +82,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="OxyPlot.Core">
-      <Version>2.0.0</Version>
+      <Version>2.1.0</Version>
     </PackageReference>
     <PackageReference Include="System.Collections">
       <Version>4.3.0</Version>

--- a/Source/OxyPlot.Xamarin.iOS/PlotView.cs
+++ b/Source/OxyPlot.Xamarin.iOS/PlotView.cs
@@ -313,7 +313,8 @@ namespace OxyPlot.Xamarin.iOS
                         context.FillRect (rect);
                     }
 
-                    actualModel.Render(renderer, rect.Width, rect.Height);
+                    OxyRect orect = new OxyRect(0, 0, rect.Width, rect.Height);
+                    actualModel.Render(renderer, orect);
                 }
             }
         }


### PR DESCRIPTION
This updates OxyPlot.Core from 2.0.0 to 2.1.0 and implements the necessary API changes. It should fix #124.

It would be great if some OxyPlot maintainer could have a look at this. @objorke @VisualMelon 